### PR TITLE
Add text-based baseball game simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# baseball_game
+# Baseball Game Simulator
+
+A simple text-based web game that simulates a dramatic baseball game.
+
+## How to Run
+
+Open `index.html` in a modern web browser and click **Start Game** to watch a randomly generated baseball showdown unfold inning by inning.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Baseball Game Simulator</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Baseball Game Simulator</h1>
+    <button id="startBtn">Start Game</button>
+    <pre id="log"></pre>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,71 @@
+const startBtn = document.getElementById('startBtn');
+const log = document.getElementById('log');
+
+startBtn.addEventListener('click', startGame);
+
+function startGame() {
+    log.textContent = '';
+    let inning = 1;
+    let homeScore = 0;
+    let awayScore = 0;
+    const plays = [
+        'smashes a towering home run',
+        'rips a double down the line',
+        'bloops a single into center',
+        'works a walk after a gritty at-bat',
+        'strikes out swinging',
+        'launches a sacrifice fly',
+        'steals second base',
+        'grounds into a double play'
+    ];
+
+    while (true) {
+        logLine(`Inning ${inning}`);
+        // Top half
+        let awayRuns = randomRuns();
+        awayScore += awayRuns;
+        logLine(`Top: Away team ${describePlay(plays, awayRuns)}`);
+
+        let playBottom = true;
+        if (inning >= 9 && homeScore > awayScore) {
+            playBottom = false; // Home team already leads, game ends
+        }
+
+        if (playBottom) {
+            let homeRuns = randomRuns();
+            homeScore += homeRuns;
+            logLine(`Bottom: Home team ${describePlay(plays, homeRuns)}`);
+        } else {
+            logLine('Bottom: Home team does not bat.');
+        }
+
+        if (inning >= 9 && homeScore !== awayScore) {
+            break; // game decided
+        }
+        inning++;
+    }
+
+    logLine('\nFinal Score - Away ' + awayScore + ', Home ' + homeScore);
+    const winner = homeScore > awayScore ? 'Home' : 'Away';
+    logLine(`${winner} team wins in dramatic fashion!`);
+}
+
+function randomRuns() {
+    const r = Math.random();
+    if (r < 0.6) return 0;
+    if (r < 0.8) return 1;
+    if (r < 0.95) return 2;
+    return 3;
+}
+
+function describePlay(plays, runs) {
+    const event = plays[Math.floor(Math.random() * plays.length)];
+    if (runs > 0) {
+        return `${event} for ${runs} run${runs > 1 ? 's' : ''}!`;
+    }
+    return `${event} but fails to score.`;
+}
+
+function logLine(text) {
+    log.textContent += text + '\n';
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,17 @@
+body {
+    font-family: monospace;
+    background-color: #f0f0f0;
+    padding: 20px;
+}
+
+h1 {
+    text-align: center;
+}
+
+#log {
+    background: #fff;
+    padding: 10px;
+    border: 1px solid #ccc;
+    height: 400px;
+    overflow-y: scroll;
+}


### PR DESCRIPTION
## Summary
- add simple text-based baseball game simulator with start button
- include styles and README instructions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a0f7c1e4832bb58d34d4ff2d5f1c