### PR TITLE
Add basic Jest tests for game logic

### DIFF
--- a/__tests__/game.test.js
+++ b/__tests__/game.test.js
@@ -1,0 +1,45 @@
+const { randomRuns, describePlay } = require('../script');
+
+describe('randomRuns', () => {
+  afterEach(() => {
+    jest.spyOn(Math, 'random').mockRestore();
+  });
+
+  test('returns 0 when random < 0.6', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.59);
+    expect(randomRuns()).toBe(0);
+  });
+
+  test('returns 1 when random is between 0.6 and 0.8', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.7);
+    expect(randomRuns()).toBe(1);
+  });
+
+  test('returns 2 when random is between 0.8 and 0.95', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.9);
+    expect(randomRuns()).toBe(2);
+  });
+
+  test('returns 3 when random >= 0.95', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.97);
+    expect(randomRuns()).toBe(3);
+  });
+});
+
+describe('describePlay', () => {
+  afterEach(() => {
+    jest.spyOn(Math, 'random').mockRestore();
+  });
+
+  const plays = ['hit a single', 'hit a double'];
+
+  test('formats scoring plays with correct pluralization', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0);
+    expect(describePlay(plays, 2)).toBe('hit a single for 2 runs!');
+  });
+
+  test('formats zero run plays', () => {
+    jest.spyOn(Math, 'random').mockReturnValue(0.6); // select second play
+    expect(describePlay(plays, 0)).toBe('hit a double but fails to score.');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,1 +1,16 @@
-
+{
+  "name": "baseball_game",
+  "version": "1.0.0",
+  "description": "A simple text-based web game that simulates a dramatic baseball game.",
+  "main": "script.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,7 +1,14 @@
-const startBtn = document.getElementById('startBtn');
-const log = document.getElementById('log');
-
-startBtn.addEventListener('click', startGame);
+// DOM elements may not exist in non-browser environments (e.g., tests)
+let startBtn;
+let log;
+if (typeof document !== 'undefined') {
+    startBtn = document.getElementById('startBtn');
+    log = document.getElementById('log');
+    startBtn.addEventListener('click', startGame);
+} else {
+    // Fallback object so functions can append text during tests
+    log = { textContent: '' };
+}
 
 function startGame() {
     log.textContent = '';
@@ -68,4 +75,9 @@ function describePlay(plays, runs) {
 
 function logLine(text) {
     log.textContent += text + '\n';
+}
+
+// Export functions for testing in Node environment
+if (typeof module !== 'undefined') {
+    module.exports = { randomRuns, describePlay };
 }


### PR DESCRIPTION
## Summary
- guard DOM usage and export game functions for testing
- configure Jest and add tests covering scoring logic and play descriptions

## Testing
- `npm install --save-dev jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8db56aecc832b89051b3deff46d62