### PR TITLE
Refactor inning loop to explicit condition

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,7 +5,6 @@ startBtn.addEventListener('click', startGame);
 
 function startGame() {
     log.textContent = '';
-    let inning = 1;
     let homeScore = 0;
     let awayScore = 0;
     const plays = [
@@ -19,7 +18,8 @@ function startGame() {
         'grounds into a double play'
     ];
 
-    while (true) {
+    const MAX_INNINGS = 12;
+    for (let inning = 1; inning <= MAX_INNINGS && (inning <= 9 || homeScore === awayScore); inning++) {
         logLine(`Inning ${inning}`);
         // Top half
         let awayRuns = randomRuns();
@@ -38,16 +38,15 @@ function startGame() {
         } else {
             logLine('Bottom: Home team does not bat.');
         }
-
-        if (inning >= 9 && homeScore !== awayScore) {
-            break; // game decided
-        }
-        inning++;
     }
 
     logLine('\nFinal Score - Away ' + awayScore + ', Home ' + homeScore);
-    const winner = homeScore > awayScore ? 'Home' : 'Away';
-    logLine(`${winner} team wins in dramatic fashion!`);
+    if (homeScore === awayScore) {
+        logLine('The game ends in a tie after extra innings.');
+    } else {
+        const winner = homeScore > awayScore ? 'Home' : 'Away';
+        logLine(`${winner} team wins in dramatic fashion!`);
+    }
 }
 
 function randomRuns() {


### PR DESCRIPTION
## Summary
- replace infinite `while(true)` with inning-based `for` loop capped at 12 innings
- handle ties explicitly and report if extra innings end without a winner

## Testing
- `node - <<'NODE'` (simulated DOM run with deterministic scoring)
- `npm test` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8db50f62c832bb616376e3edc69b1